### PR TITLE
Fix web add using CSV defaults

### DIFF
--- a/test_tracker.py
+++ b/test_tracker.py
@@ -94,5 +94,22 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].calories, 105)
 
+    def test_add_from_default_csv(self):
+        class Args:
+            pass
+
+        args = Args()
+        args.name = 'Rice'
+        args.calories = None
+        args.carbs = None
+        args.protein = None
+        args.fat = None
+        args.micro = []
+        args.csv = None
+        add_food(args)
+        items = load_log()
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].carbs, 28)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tracker.py
+++ b/tracker.py
@@ -6,11 +6,8 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 
-LOG_FILE = Path('daily_log.json')
-DEFAULT_CSV = Path('data/food.csv')
-from typing import Dict, List, Tuple
-
-LOG_FILE = Path('daily_log.json')
+LOG_FILE = Path("daily_log.json")
+DEFAULT_CSV = Path("data/food.csv")
 
 @dataclass
 class FoodItem:
@@ -77,29 +74,30 @@ def get_totals() -> Tuple[float, float, float, float, Dict[str, float]]:
 
 
 def add_food(args: argparse.Namespace) -> None:
+    """Add a food entry to the daily log."""
     items = load_log()
-    # if a CSV is provided, attempt to fill missing values from it
-    if args.csv:
-        row = find_food_row(args.name, Path(args.csv))
-        if row:
-            if args.calories is None:
-                args.calories = float(row.get('Data.Kilocalories', 0) or 0)
-            if args.carbs is None:
-                args.carbs = float(row.get('Data.Carbohydrate', 0) or 0)
-            if args.protein is None:
-                args.protein = float(row.get('Data.Protein', 0) or 0)
-            if args.fat is None:
-                args.fat = float(row.get('Data.Fat.Total Lipid', 0) or 0)
-            if not args.micro:
-                # pick remaining nutrient columns as micros
-                for k, v in row.items():
-                    if k.startswith('Data.') and k not in (
-                        'Data.Kilocalories',
-                        'Data.Carbohydrate',
-                        'Data.Protein',
-                        'Data.Fat.Total Lipid',
-                    ) and v:
-                        args.micro.append(f"{k}={v}")
+
+    csv_path = Path(args.csv) if getattr(args, "csv", None) else DEFAULT_CSV
+    row = find_food_row(args.name, csv_path)
+    if row:
+        if args.calories is None:
+            args.calories = float(row.get("Data.Kilocalories", 0) or 0)
+        if args.carbs is None:
+            args.carbs = float(row.get("Data.Carbohydrate", 0) or 0)
+        if args.protein is None:
+            args.protein = float(row.get("Data.Protein", 0) or 0)
+        if args.fat is None:
+            args.fat = float(row.get("Data.Fat.Total Lipid", 0) or 0)
+        if not args.micro:
+            for k, v in row.items():
+                if k.startswith("Data.") and k not in (
+                    "Data.Kilocalories",
+                    "Data.Carbohydrate",
+                    "Data.Protein",
+                    "Data.Fat.Total Lipid",
+                ) and v:
+                    args.micro.append(f"{k}={v}")
+
     micros = parse_micros(args.micro)
     food = FoodItem(
         name=args.name,
@@ -107,13 +105,6 @@ def add_food(args: argparse.Namespace) -> None:
         carbs=args.carbs or 0,
         protein=args.protein or 0,
         fat=args.fat or 0,
-    micros = parse_micros(args.micro)
-    food = FoodItem(
-        name=args.name,
-        calories=args.calories,
-        carbs=args.carbs,
-        protein=args.protein,
-        fat=args.fat,
         micros=micros,
     )
     items.append(food)
@@ -158,13 +149,13 @@ def build_parser() -> argparse.ArgumentParser:
     add_p.add_argument("--carbs", type=float)
     add_p.add_argument("--protein", type=float)
     add_p.add_argument("--fat", type=float)
-    add_p.add_argument("--micro", action="append", default=[], help="micronutrient in name=value form")
+    add_p.add_argument(
+        "--micro",
+        action="append",
+        default=[],
+        help="micronutrient in name=value form",
+    )
     add_p.add_argument("--csv", help="CSV file to look up nutrient data")
-    add_p.add_argument("--calories", type=float, required=True)
-    add_p.add_argument("--carbs", type=float, required=True)
-    add_p.add_argument("--protein", type=float, required=True)
-    add_p.add_argument("--fat", type=float, required=True)
-    add_p.add_argument("--micro", action="append", default=[], help="micronutrient in name=value form")
     add_p.set_defaults(func=add_food)
 
     summary_p = subparsers.add_parser("summary", help="Show daily totals")

--- a/webapp.py
+++ b/webapp.py
@@ -2,7 +2,7 @@ import http.server
 import socketserver
 import urllib.parse
 from typing import Dict
-from tracker import add_food, reset, get_totals, parse_micros_string
+from tracker import add_food, reset, get_totals, DEFAULT_CSV
 
 PORT = 8000
 
@@ -18,11 +18,6 @@ def render_index() -> bytes:
       <h2>Add Food</h2>
       <form action='/add' method='post'>
         Name: <input name='name'><br>
-        Calories: <input name='calories' type='number' step='any'><br>
-        Carbs: <input name='carbs' type='number' step='any'><br>
-        Protein: <input name='protein' type='number' step='any'><br>
-        Fat: <input name='fat' type='number' step='any'><br>
-        Micros (key=value comma or space separated): <input name='micros'><br>
         <button type='submit'>Add</button>
       </form>
 
@@ -59,17 +54,15 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         if self.path == '/add':
             class Args:
                 pass
+
             args = Args()
             args.name = params.get('name', [''])[0]
-            args.calories = float(params.get('calories', ['0'])[0] or 0)
-            args.carbs = float(params.get('carbs', ['0'])[0] or 0)
-            args.protein = float(params.get('protein', ['0'])[0] or 0)
-            args.fat = float(params.get('fat', ['0'])[0] or 0)
-            micro_str = params.get('micros', [''])[0]
+            args.calories = None
+            args.carbs = None
+            args.protein = None
+            args.fat = None
             args.micro = []
-            micros = parse_micros_string(micro_str)
-            # convert dict to list for add_food
-            args.micro = [f"{k}={v}" for k,v in micros.items()]
+            args.csv = str(DEFAULT_CSV)
             add_food(args)
         elif self.path == '/reset':
             reset(None)


### PR DESCRIPTION
## Summary
- clean up tracker code
- load macros from CSV when values aren't provided
- simplify web interface to just take a food name
- add regression tests

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68617ed8cb3c832c93718e26b64429a5